### PR TITLE
Simplify shared plugins SVN

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,16 +21,22 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # See http://stackoverflow.com/questions/10894661/augeas-support-on-my-vagrant-machine
   config.vm.provision :shell, :inline => "if ! dpkg -s puppet > /dev/null; then sudo apt-get update --quiet --yes && sudo apt-get install puppet --quiet --yes; fi"
 
+  # Do some local stuff if we're provisioning
+  if ( "#{ARGV.first}" == "provision" )
+    # SSH and checkout shared plugins
+    if File.exists?('www/wp-content/themes/vip/plugins')
+      system "ssh vagrant@vip.dev -i ~/.vagrant.d/insecure_private_key 'cd /vagrant/www/wp-content/themes/vip/plugins/; svn up'"
+    else
+      system( "ssh vagrant@vip.dev -i ~/.vagrant.d/insecure_private_key 'svn co https://vip-svn.wordpress.com/plugins/ /vagrant/www/wp-content/themes/vip/plugins'" )
+    end
+  end
+
   # Provision everything we need with Puppet
   config.vm.provision :puppet do |puppet|
     puppet.module_path = "puppet/modules"
     puppet.manifests_path = "puppet/manifests"
     puppet.manifest_file  = "init.pp"
     puppet.options = ['--templatedir', '/vagrant/puppet/files']
-    puppet.facter = {
-      "svn_username" => ENV['SVN_USERNAME'],
-      "svn_password" => ENV['SVN_PASSWORD']
-    }
   end
 
 end

--- a/bin/vip-init
+++ b/bin/vip-init
@@ -42,31 +42,6 @@ git pull
 git submodule update --init --recursive
 echo ""
 
-if [ `which svn` ]; then
-    # =====================================
-    # Checkout the VIP shared plugins repo
-    # =====================================
-    echo "=================================="
-    echo "= Updating VIP Shared plugins"
-    echo "=================================="
-
-    if [ -d "www/wp-content/themes/vip/plugins" ]; then
-    	svn up www/wp-content/themes/vip/plugins
-    else
-    	mkdir -p www/wp-content/themes/vip/plugins
-    	svn co https://vip-svn.wordpress.com/plugins/ www/wp-content/themes/vip/plugins
-    fi
-    echo ""
-else
-     # TODO: Verify username and password are correct before continuing
-    echo -n "Enter your WordPress.com username: "
-    read username
-    echo -n "Enter your WordPress.com password: "
-    read -s password
-    echo ""
-    echo ""
-fi
-
 
 # =====================================
 # Start the VM (always provision, even if it's already running)
@@ -76,7 +51,7 @@ echo "= Provisioning the VM"
 echo "=================================="
 
 vagrant up --no-provision
-SVN_USERNAME="$username" SVN_PASSWORD="$password" vagrant provision
+vagrant provision
 echo ""
 
 

--- a/puppet/manifests/sections/wp.pp
+++ b/puppet/manifests/sections/wp.pp
@@ -54,21 +54,6 @@ class svn {
 		require => Exec['checkout WordPress']
 	}
 
-	# SVN checkout VIP plugins
-	exec { 'checkout plugins':
-		command => "svn co https://vip-svn.wordpress.com/plugins/ /vagrant/www/wp-content/themes/vip/plugins --username='${svn_username}' --password='${svn_password}' --non-interactive",
-		unless => "test -d/vagrant/www/wp-content/themes/vip/plugins && ls -A /vagrant/www/wp-content/themes/vip/plugins || test -z '${svn_username}' || test -z '${svn_password}'",
-		require => Package['subversion']
-	}
-
-	exec { 'svn up VIP plugins':
-		cwd => '/vagrant/www/wp-content/themes/vip/plugins',
-		command => "svn up --username='${svn_username}' --password='${svn_password}' --non-interactive",
-		unless => "test -z '${svn_username}' || test -z '${svn_password}'",
-		onlyif => 'svn info',
-		require => Exec['checkout plugins']
-	}
-
 	# SVN checkout Minileven
 	exec { 'checkout Minileven':
 		command => 'svn co https://wpcom-themes.svn.automattic.com/minileven/ /vagrant/www/wp-content/themes/pub/minileven',


### PR DESCRIPTION
This further simplifies the SVN checkout and  the vip-init script.

By passing the svn command through SSH, we still get prompted
for a username and password from the SVN program, which will
tell us if we enter the wrong info.

Needs to be tested on Windows
