### PR TITLE
Github plugins

### DIFF
--- a/puppet/manifests/sections/gitplugin.pp
+++ b/puppet/manifests/sections/gitplugin.pp
@@ -1,9 +1,10 @@
-define gitplugin ( $slug = $title, $git_urls ) {
+# GitPlugin clones a git repo into the www/wp-content/plugins directory and activates it in WordPress
+define gitplugin ( $git_urls ) {
     vcsrepo { "/srv/www/wp-content/plugins/${title}" :
         ensure   => 'present',
         source   => $git_urls[$title],
         provider => git,
-        require => [
+        require  => [
             Exec['wp install /srv/www/wp'],
             File['/srv/www/wp-content/plugins'],
         ]
@@ -12,7 +13,6 @@ define gitplugin ( $slug = $title, $git_urls ) {
     wp::plugin { $title :
         location    => '/srv/www/wp',
         networkwide => true,
-        require => Vcsrepo["/srv/www/wp-content/plugins/${title}"]
+        require     => Vcsrepo["/srv/www/wp-content/plugins/${title}"]
     }
 }
-

--- a/puppet/manifests/sections/wp.pp
+++ b/puppet/manifests/sections/wp.pp
@@ -19,7 +19,7 @@ $github_plugins = {
     'vip-scanner' => 'https://github.com/Automattic/vip-scanner',
 
     # WordPress.com
-    'jetpack' => 'https://github.com/Automattic/jetpack', 
+    'jetpack' => 'https://github.com/Automattic/jetpack',
 }
 
 # Install WordPress
@@ -36,7 +36,9 @@ exec { 'wp install /srv/www/wp':
 
 # Install GitHub Plugins
 $github_plugin_keys = keys( $github_plugins )
-gitplugin { $github_plugin_keys : }
+gitplugin { $github_plugin_keys:
+    git_urls => $github_plugins
+}
 
 # Install plugins
 wp::plugin { $plugins:


### PR DESCRIPTION
Adds a `gitplugin` resource that can be used to install a plugin via git and activate it in WordPress.

Closes #115 and #66
