### PR TITLE
Update PHP version in php manifest to 5.4.25

### DIFF
--- a/puppet/manifests/sections/php.pp
+++ b/puppet/manifests/sections/php.pp
@@ -1,5 +1,5 @@
-# Use PHP 5.4.24 like WordPress.com
-$php_version = '5.4.24-1+sury.org~precise+1'
+# Use PHP 5.4.24 like WordPress.com (except that 5.4.25 is what's available on oldstable)
+$php_version = '5.4.25-1+sury.org~precise+2'
 
 include php
 include apt


### PR DESCRIPTION
5.4.24-1+sury.org~precise+1 is no longer available in the oldstable PPA.  This version - 5.4.25-1+sury.org~precise+2 - may not perfectly mirror wp.com, but at least it can be installed.
