### PR TITLE
Filter arguments passed to bin/wp proxy to allow spaces

### DIFF
--- a/bin/wp
+++ b/bin/wp
@@ -1,4 +1,44 @@
 #!/bin/bash
 
-ARGS="$@"
-vagrant ssh -c "cd /vagrant/www/wp; /usr/bin/wp $ARGS"
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+QUOTED_ARGS=''
+
+if [ "$1" == "test-wp-filter" ]; then
+	echo ""
+fi
+
+for SINGLE_ARG in "$@"; do 
+
+	# $@ argument expansion removes quotes.
+	# Re-quote if they need it, giving special treatment to --flag=value syntax.
+	
+	FIXED=$( echo "$SINGLE_ARG" | awk -f "$DIR/wp-filter.awk" )
+
+	# Test script:
+	# 	 wp test-wp-filter escaped\ space --long_flag-name="foo bar" --single-quotes='foo bar' --escaped=foo\ bar --no-equals "foo bar" no quotes here  "Escaping \"double quotes\" is fine"
+	# 	
+	# Expected output:
+	# 	'escaped space'
+	# 	--long_flag-name='foo bar'
+	# 	--single-quotes='foo bar'
+	# 	--escaped='foo bar'
+	# 	--no-equals
+	# 	'foo bar'
+	# 	no
+	# 	quotes
+	# 	here
+	# 	'Escaping "double quotes" is fine'
+
+	if [ "$1" == "test-wp-filter" ]; then
+		echo "$FIXED"
+	else
+		QUOTED_ARGS="$QUOTED_ARGS $FIXED"
+	fi
+
+done;
+
+if [ "$1" == "test-wp-filter" ]; then
+	echo ""
+else
+	vagrant ssh -c "cd /vagrant/www/wp; /usr/bin/wp $QUOTED_ARGS"
+fi

--- a/bin/wp-filter.awk
+++ b/bin/wp-filter.awk
@@ -1,0 +1,49 @@
+# Add single quotes back to arguments with spaces,
+# because bash's $@ syntax removes them.
+# 
+# Wraps in single quotes, because Bash allows escaping of double-quotes, but not single.
+# For example, bash doesn't allow this:
+#   'Escaping \'single quotes\''
+# 
+# So we're unlikely to get an argument with single quotes in it.
+#   Edge case: user goes to great lengths, concatenating strings.
+#   See http://stackoverflow.com/questions/1250079/escaping-single-quotes-within-single-quoted-strings
+#   
+# If a user escapes double quotes, like this:
+#   "Escaping \"double quotes\""
+#   
+# The string will come through as:
+#   Escaping "double quotes"
+#   
+# Which will be converted back to:
+#   'Escaping "double quotes"'
+#   
+# Which is fine.
+
+{
+	# Check if argument contains spaces.
+	# Space escapes have already been processed.
+	if ( $0 ~ / / ) {
+
+		# Is it a flag argument following --flag=value syntax?
+		if ( $0 ~ /--([a-zA-Z0-9_-]+)=(.*)/ ) {
+			
+			# Add single quote after equals sign
+			gsub( "=", "='", $0 );
+
+			# Add single quote at end
+			print( $0 "'" )
+
+		}else {
+			# Normal argument. Wrap in single quotes
+			print( "'" $0 "'" )
+		}
+
+	}else {
+
+		# No unescaped spaces. Print as-is
+		print( $0 )
+
+	}
+
+}


### PR DESCRIPTION
**Issue**

Attempting to pass any argument or flag value with a space in it fails with the error `Too many positional arguments`. This is because bash's `$@` argument reference strips original quoting syntax.

**Use case**

Any of these will show the problem:

```
wp option add test123 "foo bar baz"
wp option add test123 'foo bar baz'
wp option add test123 foo\ bar\ baz

wp export --dir="/path with/some spaces/"
wp export --dir='/path with/some spaces/'
wp export --dir=/path\ with/some\ spaces/
```

This becomes increasingly critical for plugins like VIP Scanner, where required arguments contain spaces:

`wp vip-scanner scan-theme --theme="twentyfourteen" --scan_type="VIP Theme Review"`

**Solution**

Use awk to add quotes back to arguments that contain spaces, giving special treatment to --flag=value syntax.

**Test script**

`wp test-wp-filter escaped\ space --long_flag-name="foo bar" --single-quotes='foo bar' --escaped=foo\ bar --no-equals "foo bar" no quotes here  "Escaping \"double quotes\" is fine"`

Expected output:

```
'escaped space'
--long_flag-name='foo bar'
--single-quotes='foo bar'
--escaped='foo bar'
--no-equals
'foo bar'
no
quotes
here
 'Escaping "double quotes" is fine'
```

**Test environment**
- VIP Quickstart d68e1a2
- WP-CLI `0.15.0`
- Mac OS `10.9.3`
