### PR TITLE
Fix failing twentyfourteen install

### DIFF
--- a/puppet/manifests/sections/wp.pp
+++ b/puppet/manifests/sections/wp.pp
@@ -54,16 +54,6 @@ wp::plugin { $plugins:
   ]
 }
 
-# Install default theme
-exec { '/usr/bin/wp theme install twentyfourteen':
-  cwd     => '/srv/www/wp',
-  unless  => '/usr/bin/wp theme is-installed twentyfourteen',
-  require => [
-    Exec['wp install /srv/www/wp'],
-    File['/srv/www/wp-content/themes'],
-  ]
-}
-
 # Update all the plugins
 wp::command { 'plugin update --all':
   command  => 'plugin update --all',
@@ -100,6 +90,16 @@ vcsrepo { '/srv/www/wp-content/themes/pub':
   ensure   => 'present',
   source   => 'https://wpcom-themes.svn.automattic.com/',
   provider => svn,
+}
+
+# Network Activate some default themes
+wp::command { 'enable_and_activate_default_theme':
+  command  => 'theme enable pub/twentyfourteen --network --activate',
+  location => '/srv/www/wp',
+  require  => [
+    Exec['wp install /srv/www/wp'],
+    Vcsrepo['/srv/www/wp-content/themes/pub'],
+  ]
 }
 
 vcsrepo { '/srv/www/wp-tests':


### PR DESCRIPTION
Instead of re-downloading and installing twentyfourteen, use the copy we already check out via the wpcom-themes repo.

see #157
