### PR TITLE
Ignore WP-CLI when in development mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@
 # tests
 /www/wp-tests
 
+# WP-CLI dev mode
+/wp-cli
+
 # phpMyAdmin
 /www/phpmyadmin
 


### PR DESCRIPTION
So I can work on WP-CLI when using Quickstart
