### PR TITLE
Install WordPress importer on provision

### DIFF
--- a/puppet/manifests/sections/wp.pp
+++ b/puppet/manifests/sections/wp.pp
@@ -8,6 +8,7 @@ $plugins = [
   'log-viewer',
   'monster-widget',
   'user-switching',
+  'wordpress-importer',
 
   # WordPress.com
   'keyring',


### PR DESCRIPTION
Although VIP recommends using WP-CLI, the latter actually requires the plugin to be installed and activated

Previously #148
