### PR TITLE
Prevent redirect loops on /wp-admin/network/*

### DIFF
--- a/www/wp-content/mu-plugins/quickstart.php
+++ b/www/wp-content/mu-plugins/quickstart.php
@@ -19,3 +19,7 @@ function wpcom_vip_quickstart_fix_domain( $url, $path, $scheme = null, $blog_id 
 
 	return $url;
 }
+
+// Required to prevent infinite loop redirections from /wp-admin/network when the domain does not match 
+// what is in the DB, for example, in the AWS AMI
+add_filter( 'redirect_network_admin_request', '__return_false' );


### PR DESCRIPTION
On server installs where the used domain does not match what is in the
DB, such as the Quickstart AMI, WP gets confused and creates redirect
loops in network admin
