### PR TITLE
Updated nginx site config template to not try to rewrite 404'd static assets uri (css/js/png/jpg) to WP

### DIFF
--- a/puppet/files/nginx/vip.dev.erb
+++ b/puppet/files/nginx/vip.dev.erb
@@ -11,6 +11,15 @@ server {
  
   index index.html index.php;
  
+
+  # Don't try to rewrite static assets
+  # Just return 404
+  # The reason is pretty simple: each 404'd asset will try to pass that to WP
+  # Spawning a bunch of requests that you probably don't want and making things SLOOOOOOOW
+  location ~ \.(png|jpg|css|js)$ {
+    try_files $uri return 404;
+  }
+
   location / {
     try_files $uri $uri/ /index.php?$args;
   }


### PR DESCRIPTION
The reason for this is that in a situation where you have a bunch of not existing assets to be requested,  each of them will be rewritten to a request to WP, and this is not a desirable behavior since it slooooows things down
