### PR TITLE
Concat CSS & Javascript

### DIFF
--- a/puppet/files/nginx/vip.dev.erb
+++ b/puppet/files/nginx/vip.dev.erb
@@ -48,4 +48,10 @@ server {
     fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
     fastcgi_pass 127.0.0.1:9000;
   }
+
+  location /_static/ {
+    fastcgi_pass 127.0.0.1:9000;
+    include /etc/nginx/fastcgi_params;
+    fastcgi_param SCRIPT_FILENAME $document_root/wp-content/mu-plugins/http-concat/ngx-http-concat.php;
+  }
 }

--- a/www/wp-content/mu-plugins/http-concat/cssconcat.php
+++ b/www/wp-content/mu-plugins/http-concat/cssconcat.php
@@ -1,0 +1,177 @@
+<?php
+/*
+Plugin Name: CSS Concat
+Plugin URI: http://wp-plugins.org/#
+Description: Concatenates CSS
+Author: Automattic
+Version: 0.01
+Author URI: http://automattic.com/
+ */
+
+if ( ! defined( 'ALLOW_GZIP_COMPRESSION' ) )
+	define( 'ALLOW_GZIP_COMPRESSION', true );
+
+class WPcom_CSS_Concat extends WP_Styles {
+	private $old_styles;
+	public $allow_gzip_compression;
+
+	function __construct( $styles ) {
+		$this->old_styles = $styles;
+
+		parent::__construct();
+	}
+
+	function do_items( $handles = false, $group = false ) {
+		$handles = false === $handles ? $this->queue : (array) $handles;
+		$stylesheets = array();
+		$siteurl = site_url();
+
+		$this->all_deps( $handles );
+
+		$stylesheet_group_index = 0;
+		foreach( $this->to_do as $key => $handle ) {
+			$obj = $this->registered[$handle];
+			$obj->src = apply_filters( 'style_loader_src', $obj->src, $obj->handle );
+
+			// Core is kind of broken and returns "true" for src of "colors" handle
+			// http://core.trac.wordpress.org/attachment/ticket/16827/colors-hacked-fixed.diff
+			// http://core.trac.wordpress.org/ticket/20729
+			if ( 'colors' == $obj->handle && true === $obj->src ) {
+				$css_url = parse_url( wp_style_loader_src( $obj->src, $obj->handle ) );
+			} else {
+				$css_url = parse_url( $obj->src );
+			}
+			$extra = $obj->extra;
+
+			// Don't concat by default
+			$do_concat = false;
+
+			// Only try to concat static css files
+			if ( false !== strpos( $css_url['path'], '.css' ) )
+				$do_concat = true;
+
+			// Don't try to concat styles which are loaded conditionally (like IE stuff)
+			if ( isset( $extra['conditional'] ) )
+				$do_concat = false;
+
+			// Don't concat rtl stuff for now until concat supports it correctly
+			if ( 'rtl' === $this->text_direction && ! empty( $extra['rtl'] ) )
+				$do_concat = false;
+
+			// Don't try to concat externally hosted scripts
+			if ( ( isset( $css_url['host'] ) && ( preg_replace( '/https?:\/\//', '', $siteurl ) != $css_url['host'] ) ) )
+				$do_concat = false;
+
+			// Concat and canonicalize the paths only for
+			// existing scripts that aren't outside ABSPATH
+			$css_realpath = realpath( ABSPATH . $css_url['path'] );
+			if ( ! $css_realpath || 0 !== strpos( $css_realpath, ABSPATH ) )
+				$do_concat = false;
+			else
+				$css_url['path'] = substr( $css_realpath, strlen( ABSPATH ) - 1 );
+
+			// Allow plugins to disable concatenation of certain stylesheets.
+			$do_concat = apply_filters( 'css_do_concat', $do_concat, $handle );
+
+			if ( true === $do_concat ) {
+				$media = $obj->args;
+				if( empty( $media ) )
+					$media = 'all';
+				if ( isset( $stylesheets[ $stylesheet_group_index ] ) && ! is_array( $stylesheets[ $stylesheet_group_index ] ) )
+					$stylesheets[ $stylesheet_group_index ] = array();
+
+				$stylesheets[ $stylesheet_group_index ][ $media ][ $handle ] = $css_url['path'];
+				$this->done[] = $handle;
+			} else {
+				$stylesheet_group_index++;
+				$stylesheets[ $stylesheet_group_index ][ 'noconcat' ][] = $handle;
+				$stylesheet_group_index++;
+			}
+			unset( $this->to_do[$key] );
+		}
+
+		foreach( $stylesheets as $idx => $stylesheets_group ) {
+			foreach( $stylesheets_group as $media => $css ) {
+				if ( 'noconcat' == $media ) {
+
+					foreach( $css as $handle ) {
+						if ( $this->do_item( $handle, $group ) )
+							$this->done[] = $handle;
+					}
+					continue;
+				} elseif ( count( $css ) > 1) {
+					$paths = array_map( function( $url ) { return ABSPATH . $url; }, $css );
+					$mtime = max( array_map( 'filemtime', $paths ) );
+					$path_str = implode( $css, ',' ) . "?m=${mtime}j";
+
+					if ( $this->allow_gzip_compression ) {
+						$path_64 = base64_encode( gzcompress( $path_str ) );
+						if ( strlen( $path_str ) > ( strlen( $path_64 ) + 1 ) )
+							$path_str = '-' . $path_64;
+					}
+
+					$href = $siteurl . "/_static/??" . $path_str;
+				} else {
+					$href = $this->cache_bust_mtime( $siteurl . current( $css ) );
+				}
+
+				echo apply_filters( 'style_loader_tag', "<link rel='stylesheet' id='$media-css-$idx' href='$href' type='text/css' media='$media' />\n", $handle );
+				array_map( array( $this, 'print_inline_style' ), array_keys( $css ) );
+			}
+		}
+		return $this->done;
+	}
+
+	function cache_bust_mtime( $url ) {
+		if ( strpos( $url, '?m=' ) )
+			return $url;
+
+		$parts = parse_url( $url );
+		if ( ! isset( $parts['path'] ) || empty( $parts['path'] ) )
+			return $url;
+
+		$file = ABSPATH . ltrim( $parts['path'], '/' );
+
+		$mtime = false;
+		if ( file_exists( $file ) )
+			$mtime = filemtime( $file );
+
+		if ( ! $mtime )
+			return $url;
+
+		if ( false === strpos( $url, '?' ) ) {
+			$q = '';
+		} else {
+			list( $url, $q ) = explode( '?', $url, 2 );
+			if ( strlen( $q ) )
+				$q = '&amp;' . $q;
+		}
+
+		return "$url?m={$mtime}g{$q}";
+	}
+
+	function __isset( $key ) {
+		return isset( $this->old_styles->$key );
+	}
+
+	function __unset( $key ) {
+		unset( $this->old_styles->$key );
+	}
+
+	function &__get( $key ) {
+		return $this->old_styles->$key;
+	}
+
+	function __set( $key, $value ) {
+		$this->old_styles->$key = $value;
+	}
+}
+
+function css_concat_init() {
+	global $wp_styles;
+
+	$wp_styles = new WPcom_CSS_Concat( $wp_styles );
+	$wp_styles->allow_gzip_compression = ALLOW_GZIP_COMPRESSION;
+}
+
+add_action( 'init', 'css_concat_init' );

--- a/www/wp-content/mu-plugins/http-concat/jsconcat.php
+++ b/www/wp-content/mu-plugins/http-concat/jsconcat.php
@@ -1,0 +1,174 @@
+<?php
+/*
+Plugin Name: JS Concat
+Plugin URI: http://wp-plugins.org/#
+Description: Concatenates JS
+Author: Automattic
+Version: 0.01
+Author URI: http://automattic.com/
+ */
+
+if ( ! defined( 'ALLOW_GZIP_COMPRESSION' ) )
+	define( 'ALLOW_GZIP_COMPRESSION', true );
+
+class WPcom_JS_Concat extends WP_scripts {
+	private $old_scripts;
+	public $allow_gzip_compression;
+
+	function __construct( $scripts ) {
+		$this->old_scripts = $scripts;
+
+		parent::__construct();
+	}
+
+	function do_items( $handles = false, $group = false ) {
+		$handles = false === $handles ? $this->queue : (array) $handles;
+		$javascripts= array();
+		$siteurl = site_url();
+
+		$this->all_deps( $handles );
+		$level = 0;
+
+		foreach( $this->to_do as $key => $handle ) {
+			if ( in_array( $handle, $this->done ) || !isset( $this->registered[$handle] ) )
+				continue;
+
+			if ( ! $this->registered[$handle]->src ) { // Defines a group.
+				$this->done[] = $handle;
+				continue;
+			}
+
+			if ( 0 === $group && $this->groups[$handle] > 0 ) {
+				$this->in_footer[] = $handle;
+				unset( $this->to_do[$key] );
+				continue;
+			}
+
+			if ( false === $group && in_array( $handle, $this->in_footer, true ) )
+				$this->in_footer = array_diff( $this->in_footer, (array) $handle );
+
+			$obj = $this->registered[$handle];
+			$js_url = parse_url( $obj->src );
+			$extra = $obj->extra;
+
+			// Don't concat by default
+			$do_concat = false;
+
+			// Only try to concat static js files
+			if ( false !== strpos( $js_url['path'], '.js' ) )
+				$do_concat = true;
+
+			// Don't try to concat externally hosted scripts
+			if ( ( isset( $js_url['host'] ) && ( preg_replace( '/https?:\/\//', '', $siteurl ) != $js_url['host'] ) ) )
+				$do_concat = false;
+
+			// Concat and canonicalize the paths only for
+			// existing scripts that aren't outside ABSPATH
+			$js_realpath = realpath( ABSPATH . $js_url['path'] );
+			if ( ! $js_realpath || 0 !== strpos( $js_realpath, ABSPATH ) )
+				$do_concat = false;
+			else
+				$js_url['path'] = substr( $js_realpath, strlen( ABSPATH ) - 1 );
+
+			if ( true === $do_concat ) {
+				if ( !isset( $javascripts[$level] ) )
+					$javascripts[$level]['type'] = 'concat';
+
+				$javascripts[$level]['paths'][] = $js_url['path'];
+				$javascripts[$level]['handles'][] = $handle;
+			} else {
+				$level++;
+				$javascripts[$level]['type'] = 'do_item';
+				$javascripts[$level]['handle'] = $handle;
+				$level++;
+			}
+			unset( $this->to_do[$key] );
+		}
+
+		if ( empty( $javascripts ) )
+			return $this->done;
+
+		foreach ( $javascripts as $js_array ) {
+			if ( 'do_item' == $js_array['type'] ) {
+				if ( $this->do_item( $js_array['handle'], $group ) )
+					$this->done[] = $js_array['handle'];
+			} else if ( 'concat' == $js_array['type'] ) {
+				array_map( array( $this, 'print_extra_script' ), $js_array['handles'] );
+
+				if ( count( $js_array['paths'] ) > 1) {
+					$paths = array_map( function( $url ) { return ABSPATH . $url; }, $js_array['paths'] );
+					$mtime = max( array_map( 'filemtime', $paths ) );
+					$path_str = implode( $js_array['paths'], ',' ) . "?m=${mtime}j";
+
+					if ( $this->allow_gzip_compression ) {
+						$path_64 = base64_encode( gzcompress( $path_str ) );
+						if ( strlen( $path_str ) > ( strlen( $path_64 ) + 1 ) )
+							$path_str = '-' . $path_64;
+					}
+
+					$href = $siteurl . "/_static/??" . $path_str;
+				} else {
+					$href = $this->cache_bust_mtime( $siteurl . $js_array['paths'][0] );
+				}
+
+				$this->done = array_merge( $this->done, $js_array['handles'] );
+				echo "<script type='text/javascript' src='$href'></script>\n";
+			}
+		}
+
+		return $this->done;
+	}
+
+	function cache_bust_mtime( $url ) {
+		if ( strpos( $url, '?m=' ) )
+			return $url;
+
+		$parts = parse_url( $url );
+		if ( ! isset( $parts['path'] ) || empty( $parts['path'] ) )
+			return $url;
+
+		$file = ABSPATH . ltrim( $parts['path'], '/' );
+
+		$mtime = false;
+		if ( file_exists( $file ) )
+			$mtime = filemtime( $file );
+
+		if ( ! $mtime )
+			return $url;
+
+		if ( false === strpos( $url, '?' ) ) {
+			$q = '';
+		} else {
+			list( $url, $q ) = explode( '?', $url, 2 );
+			if ( strlen( $q ) )
+				$q = '&amp;' . $q;
+		}
+
+		return "$url?m={$mtime}g{$q}";
+	}
+
+	function __isset( $key ) {
+		return isset( $this->old_scripts->$key );
+	}
+
+	function __unset( $key ) {
+		unset( $this->old_scripts->$key );
+	}
+
+	function &__get( $key ) {
+		return $this->old_scripts->$key;
+	}
+
+	function __set( $key, $value ) {
+		$this->old_scripts->$key = $value;
+	}
+}
+
+function js_concat_init() {
+	global $wp_scripts;
+
+	$wp_scripts = new WPcom_JS_Concat( $wp_scripts );
+	$wp_scripts->allow_gzip_compression = ALLOW_GZIP_COMPRESSION;
+}
+
+add_action( 'init', 'js_concat_init' );

--- a/www/wp-content/mu-plugins/http-concat/ngx-http-concat.php
+++ b/www/wp-content/mu-plugins/http-concat/ngx-http-concat.php
@@ -1,0 +1,210 @@
+<?php
+/*
+ * Concatenation script inspired by Nginx's ngx_http_concat and Apache's modconcat modules.
+ *
+ * It follows the same pattern for enabling the concatenation. It uses two ?, like this:
+ * http://example.com/??style1.css,style2.css,foo/style3.css
+ *
+ * If a third ? is present it's treated as version string. Like this:
+ * http://example.com/??style1.css,style2.css,foo/style3.css?v=102234
+ *
+ * It will also replace the relative paths in CSS files with absolute paths.
+ */
+
+/* Config */
+$concat_max_files = 150;
+$concat_unique = true;
+$concat_types = array(
+	'css' => 'text/css',
+	'js' => 'application/x-javascript'
+);
+
+/* Constants */
+// By default determine the document root from this scripts path in the plugins dir (you can hardcode this define)
+define( 'CONCAT_FILES_ROOT', substr( dirname( __DIR__ ), 0, strpos( dirname( __DIR__ ), '/wp-content' ) ) );
+define( 'CONCAT_WP_DIR', '/wp' );
+
+function concat_http_status_exit( $status ) {
+	switch ( $status ) {
+		case 200:
+			$text = 'OK';
+			break;
+		case 400:
+			$text = 'Bad Request';
+			break;
+		case 403:
+			$text = 'Forbidden';
+			break;
+		case 404:
+			$text = 'Not found';
+			break;
+		case 500:
+			$text = 'Internal Server Error';
+			break;
+		default:
+			$text = '';
+	}
+
+	$protocol = $_SERVER['SERVER_PROTOCOL'];
+	if ( 'HTTP/1.1' != $protocol && 'HTTP/1.0' != $protocol )
+		$protocol = 'HTTP/1.0';
+
+	@header( "$protocol $status $text", true, $status );
+	exit();
+}
+
+function concat_get_mtype( $file ) {
+	global $concat_types;
+
+	$lastdot_pos = strrpos( $file, '.' );
+	if ( false === $lastdot_pos )
+		return false;
+
+	$ext = substr( $file, $lastdot_pos + 1 );
+
+	return isset( $concat_types[$ext] ) ? $concat_types[$ext] : false;
+}
+
+function concat_get_path( $uri ) {
+	if ( ! strlen( $uri ) )
+		concat_http_status_exit( 400 );
+
+	if ( false !== strpos( $uri, '..' ) || false !== strpos( $uri, "\0" ) )
+		concat_http_status_exit( 400 );
+
+	return CONCAT_FILES_ROOT . ( '/' != $uri[0] ? '/' : CONCAT_WP_DIR ) . $uri;
+}
+
+/* Main() */
+if ( !in_array( $_SERVER['REQUEST_METHOD'], array( 'GET', 'HEAD' ) ) )
+	concat_http_status_exit( 400 );
+
+// /_static/??/foo/bar.css,/foo1/bar/baz.css?m=293847g
+// or
+// /_static/??-eJzTT8vP109KLNJLLi7W0QdyDEE8IK4CiVjn2hpZGluYmKcDABRMDPM=
+$args = parse_url($_SERVER['REQUEST_URI'], PHP_URL_QUERY );
+if ( ! $args || false === strpos( $args, '?' ) )
+	concat_http_status_exit( 400 );
+
+$args = substr( $args, strpos( $args, '?' ) + 1 );
+
+// /foo/bar.css,/foo1/bar/baz.css?m=293847g
+// or
+// -eJzTT8vP109KLNJLLi7W0QdyDEE8IK4CiVjn2hpZGluYmKcDABRMDPM=
+if ( '-' == $args[0] )
+	$args = gzuncompress( base64_decode( substr( $args, 1 ) ) );
+
+// /foo/bar.css,/foo1/bar/baz.css?m=293847g
+$version_string_pos = strpos( $args, '?' );
+if ( false !== $version_string_pos )
+	$args = substr( $args, 0, $version_string_pos );
+
+// /foo/bar.css,/foo1/bar/baz.css
+$args = explode( ',', $args );
+if ( ! $args )
+	concat_http_status_exit( 400 );
+
+// array( '/foo/bar.css', '/foo1/bar/baz.css' )
+if ( 0 == count( $args ) || count( $args ) > $concat_max_files )
+	concat_http_status_exit( 400 );
+
+$last_modified = 0;
+$pre_output = '';
+$output = '';
+
+foreach ( $args as $uri ) {
+	$fullpath = concat_get_path( $uri );
+
+	if ( ! file_exists( $fullpath ) )
+		concat_http_status_exit( 404 );
+
+	$mime_type = concat_get_mtype( $fullpath );
+	if ( ! in_array( $mime_type, $concat_types ) )
+		concat_http_status_exit( 400 );
+
+	if ( $concat_unique ) {
+		if ( ! isset( $last_mime_type ) )
+			$last_mime_type = $mime_type;
+
+		if ( $last_mime_type != $mime_type )
+			concat_http_status_exit( 400 );
+	}
+
+	$stat = stat( $fullpath );
+	if ( false === $stat )
+		concat_http_status_exit( 500 );
+
+	if ( $stat['mtime'] > $last_modified )
+		$last_modified = $stat['mtime'];
+
+	$buf = file_get_contents( $fullpath );
+	if ( false === $buf )
+		concat_http_status_exit( 500 );
+
+	if ( 'text/css' == $mime_type ) {
+		$dirpath = dirname( $uri );
+
+		// url(relative/path/to/file) -> url(/absolute/and/not/relative/path/to/file)
+		$buf = preg_replace(
+			'/(:?\s*url\s*\()\s*(?:\'|")?\s*([^\/\'"\s\)](?:(?<!data:|http:|https:).)*)[\'"\s]*\)/isU',
+			'$1' . ( $dirpath == '/' ? '/' : $dirpath . '/' ) . '$2)',
+			$buf
+		);
+
+		// AlphaImageLoader(...src='relative/path/to/file'...) -> AlphaImageLoader(...src='/absolute/path/to/file'...)
+		$buf = preg_replace(
+			'/(Microsoft.AlphaImageLoader\s*\([^\)]*src=(?:\'|")?)([^\/\'"\s\)](?:(?<!http:|https:).)*)\)/isU',
+			'$1' . ( $dirpath == '/' ? '/' : $dirpath . '/' ) . '$2)',
+			$buf
+		);
+
+		// The @charset rules must be on top of the output
+		if ( 0 === strpos( $buf, '@charset' ) ) {
+			preg_replace_callback(
+				'/(?P<charset_rule>@charset\s+[\'"][^\'"]+[\'"];)/i',
+				function ( $match ) {
+					global $pre_output;
+
+					if ( 0 === strpos( $pre_output, '@charset' ) )
+						return '';
+
+					$pre_output = $match[0] . "\n" . $pre_output;
+
+					return '';
+				},
+				$buf
+			);
+		}
+
+		// Move the @import rules on top of the concatenated output.
+		// Only @charset rule are allowed before them.
+		if ( false !== strpos( $buf, '@import' ) ) {
+			$buf = preg_replace_callback(
+				'/(?P<pre_path>@import\s+(?:url\s*\()?[\'"\s]*)(?P<path>[^\'"\s](?:https?:\/\/.+\/?)?.+?)(?P<post_path>[\'"\s\)]*;)/i',
+				function ( $match ) use ( $dirpath ) {
+					global $pre_output;
+
+					if ( 0 !== strpos( $match['path'], 'http' ) && '/' != $match['path'][0] )
+						$pre_output .= $match['pre_path'] . ( $dirpath == '/' ? '/' : $dirpath . '/' ) .
+							$match['path'] . $match['post_path'] . "\n";
+					else
+						$pre_output .= $match[0] . "\n";
+
+					return '';
+				},
+				$buf
+			);
+		}
+	}
+
+	if ( 'application/x-javascript' == $mime_type )
+		$output .= "$buf;\n";
+	else
+		$output .= "$buf";
+}
+
+header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s', $last_modified ) . ' GMT' );
+header( 'Content-Length: ' . ( strlen( $pre_output ) + strlen( $output ) ) );
+header( "Content-Type: $mime_type" );
+
+echo $pre_output . $output;

--- a/www/wp-content/mu-plugins/wpcom.php
+++ b/www/wp-content/mu-plugins/wpcom.php
@@ -1,5 +1,8 @@
 <?php
 
+require __DIR__ . '/http-concat/cssconcat.php';
+require __DIR__ . '/http-concat/jsconcat.php';
+
 // Add X-hacker header
 add_action( 'send_headers', function() {
 	header( "X-hacker: If you're reading this, you should visit automattic.com/jobs and apply to join the fun, mention this header." );


### PR DESCRIPTION
Use the WordPress.com Nginx HTTP Concat plugin to
concatenate CSS and Javascript the same as WordPress.com
This is useful for catching concatenation related bugs.

Fixes #188
