### PR TITLE
Supply -q (quiet mode) when bin/wp script calls vagrant ssh

### DIFF
--- a/bin/wp
+++ b/bin/wp
@@ -40,5 +40,5 @@ done;
 if [ "$1" == "test-wp-filter" ]; then
 	echo ""
 else
-	vagrant ssh -c "cd /vagrant/www/wp; /usr/bin/wp $QUOTED_ARGS"
+	vagrant ssh -c "cd /vagrant/www/wp; /usr/bin/wp $QUOTED_ARGS" -- -q
 fi


### PR DESCRIPTION
When a script makes several calls to `bin/wp` from the host machine, each call is followed by:

> Connection to 127.0.0.1 closed.

This isn't helpful and can interfere with scripts which work with the output of `wp` calls. By supplying the `-q` (quiet mode) argument to `vagrant ssh`, this can be suppressed from being output with each WP-CLI command.
