### PR TITLE
Change DB pw generation method

### DIFF
--- a/puppet/manifests/sections/database.pp
+++ b/puppet/manifests/sections/database.pp
@@ -1,6 +1,6 @@
 
 class database::settings {
-    $mysql_password = generate('/bin/sh', '-c', '/usr/bin/openssl rand -base64 64 | xargs echo -n')
+    $mysql_password = generate('/bin/sh', '-c', '< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c${1:-64};echo -n;')
 }
 
 include database::settings


### PR DESCRIPTION
Switch to a more robust way of generating passwords; openssl has some env-specific behaviors that might cause problems - for https://github.com/Automattic/vip-quickstart/issues/126
