### PR TITLE
Set the GEOIP value to a default country ("us").

### DIFF
--- a/www/config/vip-config.php
+++ b/www/config/vip-config.php
@@ -9,3 +9,15 @@ define( 'DISALLOW_UNFILTERED_HTML', true );
  * Disable file editing and WordPress updates
  */
 define('DISALLOW_FILE_MODS', true);
+
+/**
+ * (Sort-of) Compat with wpcom-geo config
+ *
+ * On WP.com, this is automatically detected for the visiting user.
+ * Here, we fake it for performance reasons.
+ */
+if ( defined( 'GEOIP_COUNTRY_CODE_OVERRIDE' ) ) {
+	$_SERVER[ "GEOIP_COUNTRY_CODE" ] = GEOIP_COUNTRY_CODE_OVERRIDE;
+} else {
+	$_SERVER[ "GEOIP_COUNTRY_CODE" ] = 'us';
+}


### PR DESCRIPTION
Allow overrides via a constant.

Fixes #118 
