### PR TITLE
Fix wpcom_vip_quickstart_fix_domain to provide value for null $blog_id

### DIFF
--- a/www/wp-content/mu-plugins/quickstart.php
+++ b/www/wp-content/mu-plugins/quickstart.php
@@ -6,8 +6,13 @@ add_filter( 'site_url', 'wpcom_vip_quickstart_fix_domain', 9999, 4 );
 add_filter( 'home_url', 'wpcom_vip_quickstart_fix_domain', 9999, 4 );
 
 function wpcom_vip_quickstart_fix_domain( $url, $path, $scheme = null, $blog_id = null ) {
+
+	if ( is_null( $blog_id ) ) {
+		$blog_id = get_current_blog_id();
+	}
+
 	// Only apply this customization to blog 1 (which is the default installed by QS)
-	if ( ! is_null( $blog_id ) && 1 != $blog_id ) {
+	if ( 1 != $blog_id ) {
 		return $url;
 	}
 


### PR DESCRIPTION
Fixes #336.

When on `vip.local` and another site has been added to the multisite network, say `example.local`, any links to `example.local` will instead point to `vip.local` due to the [`wpcom_vip_quickstart_fix_domain` filter](https://github.com/Automattic/vip-quickstart/blob/452af6504345aba907af8db3fe7ba3c2f6eea207/www/wp-content/mu-plugins/quickstart.php#L3-L21) for `site_url`/`home_url`.

This is true of the sites listed under My Sites in the admin bar menu, and on the Sites list table in the network admin. This is because there are many situations where the `$blog_id` is not supplied to the filter. Looking at `admin-bar.php` will show this:

``` php
        switch_to_blog( $blog->userblog_id );

        $blavatar = '<div class="blavatar"></div>';

        $blogname = empty( $blog->blogname ) ? $blog->domain : $blog->blogname;
        $menu_id  = 'blog-' . $blog->userblog_id;

        $wp_admin_bar->add_menu( array(
            'parent'    => 'my-sites-list',
            'id'        => $menu_id,
            'title'     => $blavatar . $blogname,
            'href'      => admin_url(),
        ) );
```

Note that `switch_to_blog` is used, and then `admin_url()` is called which then in turn calls `get_admin_url()` with a `$blog_id` of `null` and then calls `get_site_url()`, and so this is then supplied to the `site_url` filter. So the solution is to `get_current_blog_id()` when the supplied `$blog_id` is `null`. This resolves the issue.
