### PR TITLE
Fix undefined batcache variable during phpunit execution

### DIFF
--- a/www/wp-content/mu-plugins/batcache.php
+++ b/www/wp-content/mu-plugins/batcache.php
@@ -9,8 +9,9 @@ Version: 1.2
 */
 
 // Do not load if our advanced-cache.php isn't loaded
-if ( ! is_object($batcache) || ! method_exists( $wp_object_cache, 'incr' ) )
+if ( ! isset( $batcache ) || ! is_object( $batcache ) || ! method_exists( $wp_object_cache, 'incr' ) ) {
 	return;
+}
 
 $batcache->configure_groups();
 


### PR DESCRIPTION
When running `phpunit` there is a PHP notice regarding an undefined variable `$batcache`:

```
$ phpunit

Notice: Undefined variable: batcache in /srv/www/wp-content/mu-plugins/batcache.php on line 12

Call Stack:
    0.0005     126492   1. {main}() /srv/www/wp-tests/tests/phpunit/includes/install.php:0
    0.0077     190740   2. require_once('/srv/www/wp/wp-settings.php') /srv/www/wp-tests/tests/phpunit/includes/install.php:20
    0.2889    8468088   3. include_once('/srv/www/wp-content/mu-plugins/batcache.php') /srv/www/wp/wp-settings.php:172

Installing...
Installing network...
Running as multisite...
```

This PR fixes that problem.
