### PR TITLE
Restore wptests MySQL user password to wptests per wp-tests-config.php

### DIFF
--- a/puppet/manifests/sections/database.pp
+++ b/puppet/manifests/sections/database.pp
@@ -15,7 +15,7 @@ mysql::grant { 'wordpress':
 
 mysql::grant { 'wptests':
   mysql_privileges => 'ALL',
-  mysql_password   => $database::settings::mysql_password,
+  mysql_password   => 'wptests',
   mysql_db         => 'wptests',
   mysql_user       => 'wptests',
   mysql_host       => 'localhost',


### PR DESCRIPTION
There are DB errors when attempting to run `phpunit`:

```
$ phpunit

Warning: mysqli_real_connect(): (28000/1045): Access denied for user 'wptests'@'localhost' (using password: YES) in /srv/www/wp/wp-includes/wp-db.php on line 1424
```

I believe the `wptests` MySQL user password should not have been changed to correspond to the `wordpress` password, or if it should, then the `DB_PASSWORD` will need to be updated in [`wp-tests-config.php`](https://github.com/Automattic/vip-quickstart/blob/90868da5f503bd507c6dc4d6c6bb9ffad2b1c79e/www/wp-tests/wp-tests-config.php#L24) as well.
