### PR TITLE
Allow local-config.php to override DB_HOST

### DIFF
--- a/www/wp-config.php
+++ b/www/wp-config.php
@@ -39,7 +39,9 @@ if ( ! defined( 'DB_PASSWORD' ) ) {
 }
 
 /** MySQL hostname */
-define( 'DB_HOST', 'localhost' );
+if ( ! defined( 'DB_HOST' ) ) {
+	define( 'DB_HOST', 'localhost' );
+}
 
 /** Database Charset to use in creating database tables. */
 define( 'DB_CHARSET', 'utf8' );


### PR DESCRIPTION
We want to be able to use another server for MySQL, e.g. Amazon's Relational Database Service (RDS). To do this, we need to point `DB_HOST` to a server different from `localhost`. This PR allows this constant to be overridden in `local-config.php` just like the other `DB_*` constants are.
