### PR TITLE
Allow WP_DEBUG to be disabled via local-config.php

### DIFF
--- a/www/wp-config.php
+++ b/www/wp-config.php
@@ -79,7 +79,9 @@ if ( ! defined( 'WPLANG' ) ) {
  * It is strongly recommended that plugin and theme developers use WP_DEBUG
  * in their development environments.
  */
-define( 'WP_DEBUG', true );
+if ( ! defined( 'WP_DEBUG' ) ) {
+	define( 'WP_DEBUG', true );
+}
 define( 'SAVEQUERIES', true );
 
 if ( ! defined( 'JETPACK_DEV_DEBUG' ) ) {

--- a/www/wp-config.php
+++ b/www/wp-config.php
@@ -75,9 +75,10 @@ if ( ! defined( 'WPLANG' ) ) {
 /**
  * For developers: WordPress debugging mode.
  *
- * Change this to true to enable the display of notices during development.
+ * When WP_DEBUG is true, PHP notices will be displayed during development.
  * It is strongly recommended that plugin and theme developers use WP_DEBUG
- * in their development environments.
+ * in their development environments. On a staging environment, this may be
+ * overridden to false via local-config.php
  */
 if ( ! defined( 'WP_DEBUG' ) ) {
 	define( 'WP_DEBUG', true );


### PR DESCRIPTION
Originally raised in https://github.com/Automattic/vip-quickstart/pull/171 where the objection was raised:

> I don't think we want to be able to disable WP_DEBUG in the dev environment.

However, as the preceding PHP comment “For developers: WordPress debugging mode” instructs, this comment is specifically for developers. And now VIP Quickstart is not only used as a dev environment. When using VIP Quickstart on AWS for a public staging environment, it is not desireable to have these errors displayed as they should instead be written to the `error_log`.