### PR TITLE
Only set WP_DEBUG locally

### DIFF
--- a/www/wp-config.php
+++ b/www/wp-config.php
@@ -72,14 +72,7 @@ if ( ! defined( 'WPLANG' ) ) {
 	define( 'WPLANG', '' );
 }
 
-/**
- * For developers: WordPress debugging mode.
- *
- * Change this to true to enable the display of notices during development.
- * It is strongly recommended that plugin and theme developers use WP_DEBUG
- * in their development environments.
- */
-define( 'WP_DEBUG', true );
+define( 'WP_DEBUG', @getenv( 'QUICKSTART_ENV' ) == 'virtual' );
 define( 'SAVEQUERIES', true );
 
 if ( ! defined( 'JETPACK_DEV_DEBUG' ) ) {


### PR DESCRIPTION
In a staging environment, we don't want WP_DEBUG enabled.

See #343
