### PR TITLE
Define pub/twentyfourteen as WP_DEFAULT_THEME for unit tests

### DIFF
--- a/www/wp-tests/wp-tests-config.php
+++ b/www/wp-tests/wp-tests-config.php
@@ -19,6 +19,8 @@ define( 'WP_DEBUG', true );
 // These tests will DROP ALL TABLES in the database with the prefix named below.
 // DO NOT use a production database or one that is shared with something else.
 
+define( 'WP_DEFAULT_THEME', 'pub/twentyfourteen' );
+
 define( 'DB_NAME', 'wptests' );
 define( 'DB_USER', 'wptests' );
 define( 'DB_PASSWORD', 'wptests' );


### PR DESCRIPTION
Without this, WordPress is by default comes with `twentyfifteen` as the current theme, but this theme isn't installed. In any case, it was already wrong because the default theme was  `twentyfourteen` and not `pub/twentyfourteen` as it needs to be in a VIP context.
