### PR TITLE
Allow SAVEQUERIES to be overridden in local-config

### DIFF
--- a/www/wp-config.php
+++ b/www/wp-config.php
@@ -56,7 +56,10 @@ if ( ! defined( 'WPLANG' ) ) {
  * in their development environments.
  */
 define( 'WP_DEBUG', true );
-define( 'SAVEQUERIES', true );
+
+if ( ! defined( 'SAVEQUERIES' ) ) {
+	define( 'SAVEQUERIES', true );
+}
 
 if ( ! defined( 'JETPACK_DEV_DEBUG' ) ) {
 	define( 'JETPACK_DEV_DEBUG', true );


### PR DESCRIPTION
Trying to improve performance in Quickstart. Allowing `SAVEQUERIES` to be disabled would help a bit, and wouldn't be necessary when in a physical environment (non-Vagrant).
