### PR TITLE
Remove multisite short-circuit in WP_Object_Cache::flush()

### DIFF
--- a/www/wp-content/object-cache.php
+++ b/www/wp-content/object-cache.php
@@ -189,6 +189,13 @@ class WP_Object_Cache {
 	}
 
 	function flush() {
+		$is_multisite = ( function_exists( 'is_site_admin' ) || defined( 'CUSTOM_USER_TABLE' ) && defined( 'CUSTOM_USER_META_TABLE' ) );
+
+		// Abort object cache flushing if on multisite (really, WordPress.com) when not running unit tests
+		if ( $is_multisite && ! ( defined( 'WP_TESTS_MULTISITE' ) && WP_TESTS_MULTISITE ) ) {
+			return false;
+		}
+
 		$ret = true;
 		foreach ( array_keys($this->mc) as $group )
 			$ret &= $this->mc[$group]->flush();

--- a/www/wp-content/object-cache.php
+++ b/www/wp-content/object-cache.php
@@ -189,10 +189,6 @@ class WP_Object_Cache {
 	}
 
 	function flush() {
-		// Don't flush if multi-blog.
-		if ( function_exists('is_site_admin') || defined('CUSTOM_USER_TABLE') && defined('CUSTOM_USER_META_TABLE') )
-			return true;
-
 		$ret = true;
 		foreach ( array_keys($this->mc) as $group )
 			$ret &= $this->mc[$group]->flush();


### PR DESCRIPTION
When running unit tests for our plugins in Quickstart, we've started getting assertion errors stemming from the object cache unexpectedly having a value set. I figured it could be due to Memcached Object Cache's `WP_Object_Cache::flush()` method doing a short-circuit if it determines that it is running on multisite. So I commented out that condition, re-ran the tests, and they then passed as expected.

The `WP_UnitTestCase::setUp()` method calls a `clean_up_global_scope` method which [flushes the object cache](https://github.com/xwp/wordpress-develop/blob/c67e5da8c9a885aabb5d6dd601394a672f543089/tests/phpunit/includes/testcase.php#L39-L81) to start out with a clean state. This, however, fails on VIP Quickstart because Memcached Object Cache prevents the cache from being flushed.

I'm guessing that the short-circuit logic was put there as a safeguard against flushing all of WPCOM, which would surely bring down everything. But I think that another safeguard mechanism should be put in place than hard-coding this logic. As opposed to removing the short-circuit altogether, maybe it should explicitly look for a WPCOM-specific constant, or a Quickstart-specific one.

