### PR TITLE
Update wp wrapper to reference /srv/www instead of /vagrant/www

### DIFF
--- a/bin/wp
+++ b/bin/wp
@@ -40,5 +40,5 @@ done;
 if [ "$1" == "test-wp-filter" ]; then
 	echo ""
 else
-	vagrant ssh -c "cd /vagrant/www/wp; /usr/bin/wp $QUOTED_ARGS" -- -q
+	vagrant ssh -c "cd /srv/www/wp; /usr/bin/wp $QUOTED_ARGS" -- -q
 fi


### PR DESCRIPTION
`/vagrant` is no longer available. We should be using `/srv` now.

See also ff21c5a67e0e79c9634d2286f7bbae2730249a6d.

