### PR TITLE
Fix HTTPS clone urls for git submodules: apt & ufw.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,13 +18,13 @@
 	url = https://github.com/joshbetz/puppet-wp.git
 [submodule "puppet/modules/ufw"]
 	path = puppet/modules/ufw
-	url = https://github.com/anl/puppet-ufw
+	url = https://github.com/anl/puppet-ufw.git
 [submodule "puppet/modules/vcsrepo"]
 	path = puppet/modules/vcsrepo
 	url = https://github.com/puppetlabs/puppetlabs-vcsrepo.git
 [submodule "puppet/modules/apt"]
 	path = puppet/modules/apt
-	url = https://github.com/puppetlabs/puppetlabs-apt
+	url = https://github.com/puppetlabs/puppetlabs-apt.git
 [submodule "puppet/modules/ssh"]
 	path = puppet/modules/ssh
 	url = https://github.com/attachmentgenie/attachmentgenie-ssh.git


### PR DESCRIPTION
FIxes an issue where running `vagrant provision` does not complete, and will not provision in a Windows environment.