### PR TITLE
Fix http-concat warnings & notice

### DIFF
--- a/www/wp-content/mu-plugins/http-concat/cssconcat.php
+++ b/www/wp-content/mu-plugins/http-concat/cssconcat.php
@@ -180,6 +180,10 @@ class WPcom_CSS_Concat extends WP_Styles {
 function css_concat_init() {
 	global $wp_styles;
 
+	if ( ! ( $wp_styles instanceof WP_Styles ) ) {
+		$wp_styles = new WP_Styles();
+	}
+
 	$wp_styles = new WPcom_CSS_Concat( $wp_styles );
 	$wp_styles->allow_gzip_compression = ALLOW_GZIP_COMPRESSION;
 }

--- a/www/wp-content/mu-plugins/http-concat/cssconcat.php
+++ b/www/wp-content/mu-plugins/http-concat/cssconcat.php
@@ -85,10 +85,12 @@ class WPcom_CSS_Concat extends WP_Styles {
 
 			if ( true === $do_concat ) {
 				$media = $obj->args;
-				if( empty( $media ) )
+				if ( empty( $media ) ) {
 					$media = 'all';
-				if ( ! is_array( $stylesheets[ $stylesheet_group_index ] ) )
+				}
+				if ( empty( $stylesheets[ $stylesheet_group_index ] ) || ! is_array( $stylesheets[ $stylesheet_group_index ] ) ) {
 					$stylesheets[ $stylesheet_group_index ] = array();
+				}
 
 				$stylesheets[ $stylesheet_group_index ][ $media ][ $handle ] = $css_url['path'];
 				$this->done[] = $handle;

--- a/www/wp-content/mu-plugins/http-concat/jsconcat.php
+++ b/www/wp-content/mu-plugins/http-concat/jsconcat.php
@@ -177,6 +177,10 @@ class WPcom_JS_Concat extends WP_scripts {
 function js_concat_init() {
 	global $wp_scripts;
 
+	if ( ! ( $wp_scripts instanceof WP_Scripts ) ) {
+		$wp_scripts = new WP_Scripts();
+	}
+
 	$wp_scripts = new WPcom_JS_Concat( $wp_scripts );
 	$wp_scripts->allow_gzip_compression = ALLOW_GZIP_COMPRESSION;
 }


### PR DESCRIPTION
I've been noticing Query Monitor reporting issues from `http-concat`:

* Warning: Creating default object from empty value
* Warning: in_array() expects parameter 2 to be array, null given
* Notice: Undefined offset: 2

This PR fixes the issues.
