### PR TITLE
Make sure we include submodules

### DIFF
--- a/puppet/manifests/sections/gitplugin.pp
+++ b/puppet/manifests/sections/gitplugin.pp
@@ -5,6 +5,7 @@ define gitplugin ( $git_urls ) {
         force    => true,
         source   => $git_urls[$title],
         provider => git,
+        submodules => true,
         require  => [
             Wp::Site['/srv/www/wp'],
             File['/srv/www/wp-content/plugins'],


### PR DESCRIPTION
This is required for PR 204 of VIP-Scanner that includes PHP-Parser as a sub-module.