### PR TITLE
Add .jscsrc for JSCS integration with 'wordpress' preset

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,3 @@
+{
+	"preset": "wordpress"
+}

--- a/.jscsrc
+++ b/.jscsrc
@@ -1,3 +1,8 @@
 {
-	"preset": "wordpress"
+	"preset": "wordpress",
+	"excludeFiles": [
+		"**/vendor/**",
+		"**.min.js",
+		"**/node_modules/**"
+	]
 }


### PR DESCRIPTION
See:
https://github.com/jscs-dev/node-jscs/issues/1099
https://github.com/jscs-dev/node-jscs/pull/1105
https://github.com/xwp/wp-dev-lib/issues/38
https://core.trac.wordpress.org/ticket/31823