### PR TITLE
Bump max_input_vars to 6144 to match WordPress.com

### DIFF
--- a/puppet/manifests/sections/php.pp
+++ b/puppet/manifests/sections/php.pp
@@ -61,3 +61,11 @@ exec { 'html_errors = On':
   user    => root,
   notify  => Service['php5-fpm']
 }
+
+# Bump max_input_vars to match WordPress.com
+exec { 'max_input_vars = 6144':
+  command => 'sed -i "s/;* *max_input_vars *= *[0-9]*/max_input_vars = 6144/g" /etc/php5/fpm/php.ini',
+  unless  => 'cat /etc/php5/fpm/php.ini | grep "max_input_vars = 6144"',
+  user    => root,
+  notify  => Service['php5-fpm']
+}


### PR DESCRIPTION
ref [Zendesk #39914](https://wordpressvip.zendesk.com/requests/39914)