### PR TITLE
Compat for library loading as done on wpcom

### DIFF
--- a/www/wp-content/mu-plugins/wpcom.php
+++ b/www/wp-content/mu-plugins/wpcom.php
@@ -47,3 +47,30 @@ function global_css() {
 	if ( is_rtl() )
 		wp_enqueue_style( 'h4-global-rtl', 'http://s0.wp.com/wp-content/themes/h4/global-rtl.css', array() );
 }
+
+function require_lib( $slug ) {
+	if ( !preg_match( '|^[a-z0-9/_.-]+$|i', $slug ) ) {
+		trigger_error( "Cannot load a library with invalid slug $slug.", E_USER_ERROR );
+		return;
+	}
+	$basename = basename( $slug );
+
+	if ( defined( 'ABSPATH' ) && ! defined( 'WP_CONTENT_DIR' ) ) {
+		define( 'WP_CONTENT_DIR', ABSPATH . 'wp-content' ); // no trailing slash, full paths only - WP_CONTENT_URL is defined further down
+	}
+
+	$lib_dir = WP_CONTENT_DIR . '/lib';
+	$lib_dir = apply_filters( 'require_lib_dir', $lib_dir );
+	$choices = array(
+		"$lib_dir/$slug.php",
+		"$lib_dir/$slug/0-load.php",
+		"$lib_dir/$slug/$basename.php",
+	);
+	foreach( $choices as $file_name ) {
+		if ( is_readable( $file_name ) ) {
+			require_once $file_name;
+			return;
+		}
+	}
+	trigger_error( "Cannot find a library with slug $slug.", E_USER_ERROR );
+}


### PR DESCRIPTION
See ZD 41662.

We allow libraries to be included but this is not possible to do on Quickstart because we don't have the `require_lib()` function. This PR adds that functionality so that we don't get fatals all up in our grill.