### PR TITLE
Enable error logging by default

### DIFF
--- a/puppet/manifests/sections/php.pp
+++ b/puppet/manifests/sections/php.pp
@@ -67,7 +67,7 @@ exec { 'Enable PHP-FPM error_log Override':
   command => 'sed -i "s/php_admin_value[error_log]/php_value[error_log]/g" /etc/php5/fpm/pool.d/www.conf',
   unless  => 'cat /etc/php5/fpm/pool.d/www.conf | grep "php_value[error_log]"',
   user    => root,
-  require  => Service['php5-fpm']
+  require  => Class['php::fpm::pool']
 }
 
 # Enable PHP-FPM log_errors Override
@@ -75,7 +75,7 @@ exec { 'Enable PHP-FPM log_errors Override':
   command => 'sed -i "s/php_admin_value[log_errors]/php_value[log_errors]/g" /etc/php5/fpm/pool.d/www.conf',
   unless  => 'cat /etc/php5/fpm/pool.d/www.conf | grep "php_value[log_errors]"',
   user    => root,
-  require  => Service['php5-fpm']
+  require  => Class['php::fpm::pool']
 }
 
 # Set PHP-FPM log ownership
@@ -83,5 +83,5 @@ exec { 'Set PHP-FPM log ownership':
   command => 'touch /var/log/php-fpm-www-error.log && chown www-data:www-data /var/log/php-fpm-www-error.log',
   creates  => '/var/log/php-fpm-www-error.log',
   user    => root,
-  require  => Service['php5-fpm']
+  require  => Class['php::fpm::pool']
 }

--- a/puppet/manifests/sections/php.pp
+++ b/puppet/manifests/sections/php.pp
@@ -61,3 +61,27 @@ exec { 'html_errors = On':
   user    => root,
   notify  => Service['php5-fpm']
 }
+
+# Enable PHP-FPM error_log Override
+exec { 'Enable PHP-FPM error_log Override':
+  command => 'sed -i "s/php_admin_value[error_log]/php_value[error_log]/g" /etc/php5/fpm/pool.d/www.conf',
+  unless  => 'cat /etc/php5/fpm/pool.d/www.conf | grep "php_value[error_log]"',
+  user    => root,
+  notify  => Service['php5-fpm']
+}
+
+# Enable PHP-FPM log_errors Override
+exec { 'Enable PHP-FPM log_errors Override':
+  command => 'sed -i "s/php_admin_value[log_errors]/php_value[log_errors]/g" /etc/php5/fpm/pool.d/www.conf',
+  unless  => 'cat /etc/php5/fpm/pool.d/www.conf | grep "php_value[log_errors]"',
+  user    => root,
+  notify  => Service['php5-fpm']
+}
+
+# Set PHP-FPM log ownership
+exec { 'Set PHP-FPM log ownership':
+  command => 'touch /var/log/php-fpm-www-error.log && chown www-data:www-data /var/log/php-fpm-www-error.log',
+  creates  => '/var/log/php-fpm-www-error.log',
+  user    => root,
+  notify  => Service['php5-fpm']
+}

--- a/puppet/manifests/sections/php.pp
+++ b/puppet/manifests/sections/php.pp
@@ -64,7 +64,7 @@ exec { 'html_errors = On':
 
 # Enable PHP-FPM error_log Override
 exec { 'Enable PHP-FPM error_log Override':
-  command => 'sed -i "s/php_admin_value[error_log]/php_value[error_log]/g" /etc/php5/fpm/pool.d/www.conf',
+  command => 'sed -i "s/php_admin_value\[error_log\]/php_value\[error_log\]/g" /etc/php5/fpm/pool.d/www.conf',
   unless  => 'cat /etc/php5/fpm/pool.d/www.conf | grep "php_value[error_log]"',
   user    => root,
   require  => Class['php::fpm']
@@ -72,7 +72,7 @@ exec { 'Enable PHP-FPM error_log Override':
 
 # Enable PHP-FPM log_errors Override
 exec { 'Enable PHP-FPM log_errors Override':
-  command => 'sed -i "s/php_admin_value[log_errors]/php_value[log_errors]/g" /etc/php5/fpm/pool.d/www.conf',
+  command => 'sed -i "s/php_admin_flag\[log_errors\]/php_flag\[log_errors\]/g" /etc/php5/fpm/pool.d/www.conf',
   unless  => 'cat /etc/php5/fpm/pool.d/www.conf | grep "php_value[log_errors]"',
   user    => root,
   require  => Class['php::fpm']

--- a/puppet/manifests/sections/php.pp
+++ b/puppet/manifests/sections/php.pp
@@ -67,7 +67,7 @@ exec { 'Enable PHP-FPM error_log Override':
   command => 'sed -i "s/php_admin_value[error_log]/php_value[error_log]/g" /etc/php5/fpm/pool.d/www.conf',
   unless  => 'cat /etc/php5/fpm/pool.d/www.conf | grep "php_value[error_log]"',
   user    => root,
-  require  => Class['php::fpm::pool']
+  require  => Class['php::fpm']
 }
 
 # Enable PHP-FPM log_errors Override
@@ -75,7 +75,7 @@ exec { 'Enable PHP-FPM log_errors Override':
   command => 'sed -i "s/php_admin_value[log_errors]/php_value[log_errors]/g" /etc/php5/fpm/pool.d/www.conf',
   unless  => 'cat /etc/php5/fpm/pool.d/www.conf | grep "php_value[log_errors]"',
   user    => root,
-  require  => Class['php::fpm::pool']
+  require  => Class['php::fpm']
 }
 
 # Set PHP-FPM log ownership
@@ -83,5 +83,5 @@ exec { 'Set PHP-FPM log ownership':
   command => 'touch /var/log/php-fpm-www-error.log && chown www-data:www-data /var/log/php-fpm-www-error.log',
   creates  => '/var/log/php-fpm-www-error.log',
   user    => root,
-  require  => Class['php::fpm::pool']
+  require  => Class['php::fpm']
 }

--- a/puppet/manifests/sections/php.pp
+++ b/puppet/manifests/sections/php.pp
@@ -67,7 +67,7 @@ exec { 'Enable PHP-FPM error_log Override':
   command => 'sed -i "s/php_admin_value[error_log]/php_value[error_log]/g" /etc/php5/fpm/pool.d/www.conf',
   unless  => 'cat /etc/php5/fpm/pool.d/www.conf | grep "php_value[error_log]"',
   user    => root,
-  notify  => Service['php5-fpm']
+  require  => Service['php5-fpm']
 }
 
 # Enable PHP-FPM log_errors Override
@@ -75,7 +75,7 @@ exec { 'Enable PHP-FPM log_errors Override':
   command => 'sed -i "s/php_admin_value[log_errors]/php_value[log_errors]/g" /etc/php5/fpm/pool.d/www.conf',
   unless  => 'cat /etc/php5/fpm/pool.d/www.conf | grep "php_value[log_errors]"',
   user    => root,
-  notify  => Service['php5-fpm']
+  require  => Service['php5-fpm']
 }
 
 # Set PHP-FPM log ownership
@@ -83,5 +83,5 @@ exec { 'Set PHP-FPM log ownership':
   command => 'touch /var/log/php-fpm-www-error.log && chown www-data:www-data /var/log/php-fpm-www-error.log',
   creates  => '/var/log/php-fpm-www-error.log',
   user    => root,
-  notify  => Service['php5-fpm']
+  require  => Service['php5-fpm']
 }

--- a/puppet/manifests/sections/wp.pp
+++ b/puppet/manifests/sections/wp.pp
@@ -86,6 +86,15 @@ $wp_content_dirs = [
   '/srv/www/wp-content/uploads',
 ]
 
+file { '/srv/www/wp-content':
+    ensure  => directory,
+    recurse => false,
+    mode    => 0775,
+    owner   => 'www-data',
+    group   => 'www-data',
+}
+
+
 file { $wp_content_dirs:
     ensure  => directory,
     recurse => true,

--- a/puppet/manifests/sections/wp.pp
+++ b/puppet/manifests/sections/wp.pp
@@ -79,7 +79,6 @@ class { 'wp::cli': ensure  => installed }
 
 # Make sure the wp-content directories exists
 $wp_content_dirs = [
-  '/srv/www/wp-content',
   '/srv/www/wp-content/themes',
   '/srv/www/wp-content/plugins',
   '/srv/www/wp-content/upgrade',

--- a/puppet/manifests/sections/wp.pp
+++ b/puppet/manifests/sections/wp.pp
@@ -79,6 +79,7 @@ class { 'wp::cli': ensure  => installed }
 
 # Make sure the wp-content directories exists
 $wp_content_dirs = [
+  '/srv/www/wp-content',
   '/srv/www/wp-content/themes',
   '/srv/www/wp-content/plugins',
   '/srv/www/wp-content/upgrade',


### PR DESCRIPTION
This will allow error logs to be writable by default, and allow `WP_DEBUG_LOG` to be used.

To do this we need to:

* Change `php_admin_value[error_log]` and `php_admin_flag[log_errors]` in `/etc/php5/fpm/pool.d/www.conf` to [overridable values](http://php.net/manual/en/configuration.changes.php)
* Create `/var/log/php-fpm-www-error.log` and allow `www-data` to write to it
* Change `/srv/www/wp-content` to allow `www-data` to write to it