### PR TITLE
Put Keyring into headless mode, to better match wpcom environment

### DIFF
--- a/www/wp-config.php
+++ b/www/wp-config.php
@@ -55,6 +55,9 @@ if ( ! defined( 'JETPACK_DEV_DEBUG' ) ) {
 	define( 'JETPACK_DEV_DEBUG', true );
 }
 
+// Put Keyring into headless mode
+define( 'KEYRING__HEADLESS_MODE', true );
+
 /* Content Directory */
 define( 'WP_CONTENT_DIR', dirname( __FILE__ ) . '/wp-content' );
 define( 'WP_CONTENT_URL', 'http://' . $_SERVER['HTTP_HOST'] . '/wp-content' );


### PR DESCRIPTION
It's been noted by VIP clients that on Quickstart, the Keyring Tools menu page is visible. This is confusing, as there is no such page on WordPress.com VIP.

This is because on VIP, Keyring is in headless mode.

To better mirror production, Quickstart should also put Keyring in headless mode. This PR does that.