### PR TITLE
ensure mysql has been installed before modifing it

### DIFF
--- a/puppet/manifests/sections/database.pp
+++ b/puppet/manifests/sections/database.pp
@@ -23,5 +23,6 @@ mysql::grant { 'wptests':
 
 mysql::augeas {
   'mysqld/log_slow_queries':
-    value => '/var/log/mysql/mysql-slow.log';
+    value => '/var/log/mysql/mysql-slow.log',
+    require => Package['mysql'];
 }


### PR DESCRIPTION
Occasionally, depending on how the dependency graph shook out, the provisioner would attempt to modify the slow query log setting before mysql was installed. This small fix prevents that.