### PR TITLE
use inifile and Augeas instead of grep and sed for php.ini and fpm config

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,3 +28,6 @@
 [submodule "puppet/modules/ssh"]
 	path = puppet/modules/ssh
 	url = https://github.com/attachmentgenie/attachmentgenie-ssh.git
+[submodule "puppet/modules/inifile"]
+	path = puppet/modules/inifile
+	url = https://github.com/puppetlabs/puppetlabs-inifile.git

--- a/puppet/manifests/sections/php.pp
+++ b/puppet/manifests/sections/php.pp
@@ -50,7 +50,25 @@ class {
     require => Package['php5-common'];
 }
 
-php::fpm::pool { 'www': user => 'www-data' }
+php::fpm::pool {
+  'www':
+    user => 'www-data',
+    log_errors => false,
+    php_value => {
+      'error_log' => '/var/log/php-fpm/www-error.log'
+    },
+    php_flag => {
+      'log_errors' => 'on'
+    },
+    require  => Class['php::fpm']
+}
+
+php::fpm::config {
+  'html_errors':
+    setting => 'html_errors',
+    value   => 'On',
+    require  => Class['php::fpm']
+}
 
 # Install PHP_CodeSniffer and the WordPress coding standard
 package { 'pear.php.net/PHP_CodeSniffer':
@@ -71,31 +89,6 @@ exec { 'add wordpress cs to phpcs':
   unless  => 'phpcs -i | grep "WordPress"',
   user    => root,
   require => Vcsrepo['/usr/share/php/PHP/CodeSniffer/Standards/WordPress']
-}
-
-# Turn on html_errors
-exec { 'html_errors = On':
-  command => 'sed -i "s/html_errors = Off/html_errors = On/g" /etc/php5/fpm/php.ini',
-  unless  => 'cat /etc/php5/fpm/php.ini | grep "html_errors = On"',
-  user    => root,
-  notify  => Service['php5-fpm'],
-  require => Class['php::fpm']
-}
-
-# Enable PHP-FPM error_log Override
-exec { 'Enable PHP-FPM error_log Override':
-  command => 'sed -i "s/php_admin_value\[error_log\]/php_value\[error_log\]/g" /etc/php5/fpm/pool.d/www.conf',
-  unless  => 'cat /etc/php5/fpm/pool.d/www.conf | grep "php_value[error_log]"',
-  user    => root,
-  require  => Class['php::fpm']
-}
-
-# Enable PHP-FPM log_errors Override
-exec { 'Enable PHP-FPM log_errors Override':
-  command => 'sed -i "s/php_admin_flag\[log_errors\]/php_flag\[log_errors\]/g" /etc/php5/fpm/pool.d/www.conf',
-  unless  => 'cat /etc/php5/fpm/pool.d/www.conf | grep "php_value[log_errors]"',
-  user    => root,
-  require  => Class['php::fpm']
 }
 
 # Set PHP-FPM log ownership

--- a/puppet/manifests/sections/php.pp
+++ b/puppet/manifests/sections/php.pp
@@ -52,22 +52,22 @@ class {
 
 php::fpm::pool {
   'www':
-    user => 'www-data',
+    user       => 'www-data',
     log_errors => false,
-    php_value => {
+    php_value  => {
       'error_log' => '/var/log/php-fpm/www-error.log'
     },
-    php_flag => {
+    php_flag   => {
       'log_errors' => 'on'
     },
-    require  => Class['php::fpm']
+    require    => Class['php::fpm']
 }
 
 php::fpm::config {
   'html_errors':
     setting => 'html_errors',
     value   => 'On',
-    require  => Class['php::fpm']
+    require => Class['php::fpm']
 }
 
 # Install PHP_CodeSniffer and the WordPress coding standard
@@ -94,7 +94,7 @@ exec { 'add wordpress cs to phpcs':
 # Set PHP-FPM log ownership
 exec { 'Set PHP-FPM log ownership':
   command => 'touch /var/log/php-fpm-www-error.log && chown www-data:www-data /var/log/php-fpm-www-error.log',
-  creates  => '/var/log/php-fpm-www-error.log',
+  creates => '/var/log/php-fpm-www-error.log',
   user    => root,
-  require  => Class['php::fpm']
+  require => Class['php::fpm']
 }


### PR DESCRIPTION
This PR isn't prompted by a bug as much as a desire to cut down on the number of actions puppet needs to execute during a reprovisioning. It adds the [puppetlabs-inifile](https://github.com/puppetlabs/puppetlabs-inifile) module so that [puppet-php](https://github.com/jippi/puppet-php) can use Augeas to edit `/etc/php5/fpm/php.ini` and `/etc/php5/fpm/pool.d/www.conf` natively instead of relying on awk and sed being run every time the puppet-php module overwrites their modifications. This means that after the initial provisioning, puppet should stop touching the php settings entirely, and the only updates will be pulling the various wordpress-related repositories up-to-date with their remotes.