### PR TITLE
Use the function name on VIP that filters out the intermediate image sizes

### DIFF
--- a/www/wp-content/mu-plugins/wpcom.php
+++ b/www/wp-content/mu-plugins/wpcom.php
@@ -24,12 +24,14 @@ add_action( 'admin_menu', function() {
 add_filter( 'global_terms_enabled', '__return_true' );
 
 // Disable automatic creation of intermediate images
-add_filter( 'intermediate_image_sizes', function( $sizes ) {
-    if ( ! defined( 'JETPACK_DEV_DEBUG' ) || ! JETPACK_DEV_DEBUG )
-	return array();
+add_filter( 'intermediate_image_sizes', 'wpcom_intermediate_sizes' );
+function wpcom_intermediate_sizes ( $sizes ) {
+    if ( ! defined( 'JETPACK_DEV_DEBUG' ) || ! JETPACK_DEV_DEBUG ) {
+	    return array();
+    }
 
     return $sizes;
-});
+}
 
 // Check alloptions on every pageload
 add_action( 'init', function() {


### PR DESCRIPTION
is called 'wpcom_intermediate_image_sizes'. Occasionally someone may need to
remove that filter.

Using the same function name makes it possible to remove and re-add the intermediate image sizes filter.

This adjustment makes Quickstart function like production.

Fixes #496.