### PR TITLE
Move to WordPress v4.6 rather than trunk

### DIFF
--- a/puppet/manifests/sections/wp.pp
+++ b/puppet/manifests/sections/wp.pp
@@ -105,8 +105,8 @@ file { $wp_content_dirs:
 
 # VCS Checkout
 vcsrepo { '/srv/www/wp':
-  ensure   => latest,
-  source   => 'https://core.svn.wordpress.org/trunk/',
+  ensure   => present,
+  source   => 'https://core.svn.wordpress.org/tags/4.6/',
   provider => svn,
 }
 


### PR DESCRIPTION
Starts the move to use latest stable rather than trunk for better syncing with WordPress.com