### PR TITLE
Directory permissons

### DIFF
--- a/puppet/manifests/sections/wp.pp
+++ b/puppet/manifests/sections/wp.pp
@@ -149,7 +149,7 @@ cron { '/srv/www/wp-tests':
 cron { 'check perms on content dirs ':
   command => 'for path in /srv/www/wp-content/themes /srv/www/wp-content/plugins /srv/www/wp-content/upgrade /srv/www/wp-content/uploads; find $path -type d -exec chmod 775 {} \;; find $path -type f -exec chmod 664 {} \;; chown -R www-data:www-data $path; done',
   minute => '0',
-  hour = '2',
+  hour => '2',
 }
 
 if 'physical' == $::virtual {

--- a/puppet/manifests/sections/wp.pp
+++ b/puppet/manifests/sections/wp.pp
@@ -146,12 +146,6 @@ cron { '/srv/www/wp-tests':
   hour    => '*',
 }
 
-cron { 'check perms on content dirs ':
-  command => 'for path in /srv/www/wp-content/themes /srv/www/wp-content/plugins /srv/www/wp-content/upgrade /srv/www/wp-content/uploads; do find $path -type d -exec chmod 775 {} \;; find $path -type f -exec chmod 664 {} \;; chown -R www-data:www-data $path; done',
-  minute => '0',
-  hour => '2',
-}
-
 if 'physical' == $::virtual {
   # Create a local config
   file { 'local-config.php':

--- a/puppet/manifests/sections/wp.pp
+++ b/puppet/manifests/sections/wp.pp
@@ -147,7 +147,7 @@ cron { '/srv/www/wp-tests':
 }
 
 cron { 'check perms on content dirs ':
-  command => 'for path in /srv/www/wp-content/themes /srv/www/wp-content/plugins /srv/www/wp-content/upgrade /srv/www/wp-content/uploads; find $path -type d -exec chmod 775 {} \;; find $path -type f -exec chmod 664 {} \;; chown -R www-data:www-data $path; done',
+  command => 'for path in /srv/www/wp-content/themes /srv/www/wp-content/plugins /srv/www/wp-content/upgrade /srv/www/wp-content/uploads; do find $path -type d -exec chmod 775 {} \;; find $path -type f -exec chmod 664 {} \;; chown -R www-data:www-data $path; done',
   minute => '0',
   hour => '2',
 }

--- a/puppet/manifests/sections/wp.pp
+++ b/puppet/manifests/sections/wp.pp
@@ -97,8 +97,8 @@ file { '/srv/www/wp-content':
 
 file { $wp_content_dirs:
     ensure  => directory,
-    recurse => true,
-    mode    => 0664,
+    recurse => false,
+    mode    => 0775,
     owner   => 'www-data',
     group   => 'www-data',
 }
@@ -144,6 +144,12 @@ cron { '/srv/www/wp-tests':
   command => '/usr/bin/svn up /srv/www/wp-tests > /dev/null 2>&1',
   minute  => '0',
   hour    => '*',
+}
+
+cron { 'check perms on content dirs ':
+  command => 'for path in /srv/www/wp-content/themes /srv/www/wp-content/plugins /srv/www/wp-content/upgrade /srv/www/wp-content/uploads; find $path -type d -exec chmod 775 {} \;; find $path -type f -exec chmod 664 {} \;; chown -R www-data:www-data $path; done',
+  minute => '0',
+  hour = '2',
 }
 
 if 'physical' == $::virtual {


### PR DESCRIPTION
On 10up's VIP staging server we have run into problems of not being able to re-run puppet provisioning to update our server because of the size of our uploads directory, approx 260GB. I have recently provisioned an upgraded server for us, I tested running puppet after moving over our uploadss and the puppet process ran for ~6 hours before being killed off by the system oom killer.

This PR removes the recursive permissions checking from the $wp_content_dirs directories and instead installs a cronjob to enforce those same permissions. On my server, this cronjob executes in 25-30 minutes, much better than the 6+ hours of letting puppet handle it. This also has the side effect of enforcing those permissions independently of puppet runs
