### PR TITLE
Require PHP before configure

### DIFF
--- a/puppet/manifests/sections/php.pp
+++ b/puppet/manifests/sections/php.pp
@@ -32,4 +32,5 @@ file_line { 'php error_log':
 	path  => '/etc/php/7.0/fpm/php.ini',
 	line  => 'error_log = /tmp/php-errors',
 	match => '^error_log',
+	require => Package['php7.0-fpm']
 }


### PR DESCRIPTION
Currently we're to setting `error_log = /tmp/php-errors` in `/etc/php/7.0/fpm/php.ini` without ensuring that `php7.0-fpm` is actually installed which produces the following error:

> INFO interface: info: err: /Stage[main]//File_line[php error_log]: Could not evaluate: No such file or directory - /etc/php/7.0/fpm/php.ini

This change fixes that.