### PR TITLE
Re-add max_input_vars for PHP7 support

### DIFF
--- a/puppet/manifests/sections/php.pp
+++ b/puppet/manifests/sections/php.pp
@@ -34,3 +34,11 @@ file_line { 'php error_log':
 	match => '^error_log',
 	require => Package['php7.0-fpm']
 }
+
+# Bump max_input_vars to match WordPress.com
+file_line { 'max_input_vars = 6144':
+	path  => '/etc/php/7.0/fpm/php.ini',
+	line  => 'max_input_vars = 6144',
+	match => '^(; max_input_vars|max_input_vars)',
+	require => Package['php7.0-fpm']
+}


### PR DESCRIPTION
Since the upgrade of PHP7, we lost modules and the ability to have the max_input_vars match WordPress.com. this resolves the issue with max_input_vars.